### PR TITLE
use rh-postgresql12 by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,14 +5,15 @@ pgs9stig_cat2: yes
 pgs9stig_cat3: yes
 
 pgs9stig_postgres_packages:
-    - postgresql96-server
+    - rh-postgresql12-postgresql-server-syspaths
+    - rh-postgresql12-postgresql-syspaths
 
 pgs9stig_configure_pgaudit: yes
 pgs9stig_pgaudit_packages:
-    - pgaudit11_96
+    - rh-postgresql12-pgaudit
 
 pgs9stig_postgres_user: postgres
-pgs9stig_postgres_service: postgresql-9.6
+pgs9stig_postgres_service: postgresql
 
 pgs9stig_allowed_superusers:
     - "{{ pgs9stig_postgres_user }}"


### PR DESCRIPTION
Red Hat now ships a version of postgres with pgaudit.  Let's use that by default.