### PR TITLE
idempotence with subscription-manager yum plugin

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -1382,7 +1382,8 @@
             warn: no
         register: pgs9_00_009200_patch
         changed_when:
-            - pgs9_00_009200_patch.stdout != "No Packages marked for removal" or
+            - >-
+              "No Packages marked for removal" not in pgs9_00_009200_patch.stdout or
               pgs9_00_009200_audit_unneeded.results | length > 0
         failed_when:
             - pgs9_00_009200_patch is failed


### PR DESCRIPTION
Somewhere along the line, yum started outputting to stdout which plugins are enabled.  Handle this case for idempotence. (This is a cosmetic PR only; no functionality change.)